### PR TITLE
CCN3-610: Temporarily set application expiry threshold to 1 day on TEST

### DIFF
--- a/data_coordinator/settings/build.py
+++ b/data_coordinator/settings/build.py
@@ -4,12 +4,6 @@ DEBUG = True
 
 ALLOWED_HOSTS = ['*']
 
-# Automatic deletion frequency is done in minutes
-AUTOMATIC_DELETION_FREQUENCY = 2
-
-# Expiry threshold for applications in days
-EXPIRY_THRESHOLD = 0.01
-
 DEV_APPS = [
     'debug_toolbar',
 ]

--- a/data_coordinator/settings/test.py
+++ b/data_coordinator/settings/test.py
@@ -4,6 +4,12 @@ DEBUG = True
 
 ALLOWED_HOSTS = ['*']
 
+# Automatic deletion frequency in minutes
+AUTOMATIC_DELETION_FREQUENCY = 2
+
+# Expiry threshold for applications in days
+EXPIRY_THRESHOLD = 1
+
 DEV_APPS = [
     'debug_toolbar',
 ]

--- a/data_coordinator/settings/test.py
+++ b/data_coordinator/settings/test.py
@@ -8,7 +8,7 @@ ALLOWED_HOSTS = ['*']
 AUTOMATIC_DELETION_FREQUENCY = 2
 
 # Expiry threshold for applications in days
-EXPIRY_THRESHOLD = 1
+EXPIRY_THRESHOLD = 0.04
 
 DEV_APPS = [
     'debug_toolbar',


### PR DESCRIPTION
- Temporarily set application expiry threshold to 1 day on TEST
- Revert automatic deletion settings on BUILD now testing has completed